### PR TITLE
Remove `text-indent` declaration from `<table>`

### DIFF
--- a/base.css
+++ b/base.css
@@ -353,15 +353,13 @@ iframe {
 ======================================== */
 
 /*
-1. Remove text indentation from table contents in Chrome, Edge, and Safari.
-2. Collapse border spacing.
-3. Correct table border color inheritance in Chrome, Edge, and Safari.
+1. Collapse border spacing.
+2. Correct table border color inheritance in Chrome, Edge, and Safari.
 */
 
 table {
-	text-indent: 0; /* 1 */
-	border-collapse: collapse; /* 2 */
-	border-color: currentcolor; /* 3 */
+	border-collapse: collapse; /* 1 */
+	border-color: currentcolor; /* 2 */
 }
 
 /*


### PR DESCRIPTION
Rule `table { text-indent: 0 }` is fixed in all browsers:

- Chromium: https://github.com/chromium/chromium/commit/b3ba3cc70a9936d2f04e1fcc572dbed5d7e1f3e3
- WebKit: https://github.com/WebKit/WebKit/commit/71f3e1bf7faeb221fa38585e2496a83602268e4b

As a reference, it has already been removed in [sindresorhus/modern-normalize](https://github.com/sindresorhus/modern-normalize/) (see https://github.com/sindresorhus/modern-normalize/commit/a5c26a4d8252bcb4feaa0259cbadd24dad624552).