### PR TITLE
Remove outdated normalization of button appearance

### DIFF
--- a/base.css
+++ b/base.css
@@ -356,17 +356,6 @@ textarea {
 }
 
 /*
-Correct the inability to style buttons in iOS and Safari.
-*/
-
-button,
-[type="button" i],
-[type="reset" i],
-[type="submit" i] {
-	-webkit-appearance: button;
-}
-
-/*
 Correct the text style of placeholders in Chrome and Safari.
 */
 


### PR DESCRIPTION
This rule comes from normalize.css reset, which was added in 2011 and has not been updated since: "Add -webkit-appearance:button to clickable input types, fixes inability to style them in iOS." https://github.com/csstools/normalize.css/commit/1be44f3

I've tested this on iOS and they are fully customizable without this rule: https://codepen.io/germanfrelo/pen/VYZzQvm

Related:

Currently, all three major browser engines have unprefixed the 'appearance' property and default to 'auto' for these elements:
- Gecko (Firefox) in 2020: https://bugzilla.mozilla.org/show_bug.cgi?id=1620467
- Blink (Chromium) in 2020:
  - Unprefixed: https://chromium-review.googlesource.com/c/chromium/src/+/2084776
  - Defaults to auto: https://github.com/chromium/chromium/commit/efbcef254191462cc27730a3b9f21beb5030d255
- WebKit in 2022:
  - Bug: https://bugs.webkit.org/show_bug.cgi?id=143842
  - Commit: https://github.com/WebKit/WebKit/commit/b9b2192a7370b3c3080a080ef326b22a18df1cc6
  - Safari release notes: https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/

See also https://caniuse.com/?search=appearance

The 'button' value (among others) is now "the equivalent of 'auto' for maintaining compatibility with older browsers": https://developer.mozilla.org/en-US/docs/Web/CSS/appearance#compat-auto