### PR TITLE
Remove unnecessary appearance property of input file button

### DIFF
--- a/base.css
+++ b/base.css
@@ -366,12 +366,10 @@ Correct the text style of placeholders in Chrome and Safari.
 
 /*
 1. Change font properties to 'inherit' in Safari.
-2. Correct the inability to style upload buttons in iOS and Safari.
 */
 
 ::-webkit-file-upload-button {
 	font: inherit; /* 1 */
-	-webkit-appearance: button; /* 2 */
 }
 
 /*


### PR DESCRIPTION
This CSS declaration comes from normalize.css reset, which was added in 2016 and has not been updated since: Commit: https://github.com/necolas/normalize.css/commit/26b2588335ea9a94844a062255d3415c958e0b86 Pull request: https://github.com/necolas/normalize.css/pull/574

I've tested this in Safari (and Chrome and Firefox) and it's fully customizable without this rule: https://codepen.io/germanfrelo/pen/VYZzQvm

Related:

Currently, all three major browser engines have unprefixed the 'appearance' property and default to 'auto' for these elements:
- Gecko (Firefox) in 2020: https://bugzilla.mozilla.org/show_bug.cgi?id=1620467
- Blink (Chromium) in 2020:
  - Unprefixed: https://chromium-review.googlesource.com/c/chromium/src/+/2084776
  - Defaults to auto: https://github.com/chromium/chromium/commit/efbcef254191462cc27730a3b9f21beb5030d255
- WebKit in 2022:
  - Bug: https://bugs.webkit.org/show_bug.cgi?id=143842
  - Commit: https://github.com/WebKit/WebKit/commit/b9b2192a7370b3c3080a080ef326b22a18df1cc6
  - Safari release notes: https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/

The 'button' value (among others) is now "the equivalent of 'auto' for maintaining compatibility with older browsers": https://developer.mozilla.org/en-US/docs/Web/CSS/appearance#compat-auto

Resources:
- https://caniuse.com/?search=appearance
- https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button
- https://css-tricks.com/almanac/pseudo-selectors/f/file-selector-button/