### PR TITLE
Use standardized input file button pseudo-element

### DIFF
--- a/base.css
+++ b/base.css
@@ -365,11 +365,11 @@ Correct the text style of placeholders in Chrome and Safari.
 }
 
 /*
-1. Change font properties to 'inherit' in Safari.
+Change font properties to 'inherit' in Safari.
 */
 
-::-webkit-file-upload-button {
-	font: inherit; /* 1 */
+::file-selector-button {
+	font: inherit;
 }
 
 /*


### PR DESCRIPTION
All three major browser engines have implemented the ::file-selector-button pseudo-element (previously exposed in WebKit-based browsers via the non-standard ::-webkit-file-upload-button pseudo-element):
- Gecko (Firefox) in 2020 (v82):
  - Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1662478
  - Commit: https://github.com/mozilla/gecko-dev/commit/03baee9d8af74895754627ae5a7b4c15f2a802bd
  - Release note: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/82
- Blink (Chromium) in 2021 (Chrome v89):
  - Bug: https://issues.chromium.org/issues/40132735
  - Feature: https://chromestatus.com/feature/5676301379698688
- WebKit (Safari) in 2021 (v14.1):
  - Bug: https://bugs.webkit.org/show_bug.cgi?id=219836
  - Commit: https://commits.webkit.org/232441@main
  - Release note: https://webkit.org/blog/11525/release-notes-for-safari-technology-preview-119/

Resources:
- https://webstatus.dev/features/file-selector-button
- https://caniuse.com/mdn-css_selectors_file-selector-button
- https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button
- https://css-tricks.com/almanac/pseudo-selectors/f/file-selector-button/
- https://www.bram.us/2021/04/15/identify-and-extract-pseudo-element-selectors-from-built-in-html-elements-using-devtools/