### PR TITLE
Use standardized placeholder pseudo-element

### DIFF
--- a/base.css
+++ b/base.css
@@ -359,7 +359,7 @@ textarea {
 Correct the text style of placeholders in Chrome and Safari.
 */
 
-::-webkit-input-placeholder {
+::placeholder {
 	color: inherit;
 	opacity: 0.54;
 }


### PR DESCRIPTION
All three major browser engines have implemented the unprefixed standard ::placeholder pseudo-element:

- Gecko (Firefox) since 2017 (v51):
  - Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1069012
  - Commit: https://github.com/mozilla/gecko-dev/commit/2b28c5e2a999537e9dbc3b620e3946ec05ca2662
  - Release note: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51
- Blink (Chromium) since 2017 (Chrome v57):
  - Bug: https://issues.chromium.org/issues/40474390
  - Feature: https://chromestatus.com/feature/6715780926275584
- WebKit (Safari) since 2017 (v10.1 (Safari iOS v10.3)):
  - Bug: https://bugs.webkit.org/show_bug.cgi?id=158653
  - Commit: https://commits.webkit.org/r202066
  - Release note: https://webkit.org/blog/6640/release-notes-for-safari-technology-preview-release-7/

Resources:
- Can I use: https://caniuse.com/css-placeholder
- MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder
- Spec: https://drafts.csswg.org/css-pseudo-4/#placeholder-pseudo
- Web Platform Status: https://webstatus.dev/features/placeholder