### PR TITLE
feat: Remove font-weight normalization of b & strong

### DIFF
--- a/base.css
+++ b/base.css
@@ -198,15 +198,6 @@ Replace '40px' indents with '2.5em' indents.
 ======================================== */
 
 /*
-Add the correct font weight in Chrome and Safari.
-*/
-
-b,
-strong {
-	font-weight: bolder;
-}
-
-/*
 1. Correct the inheritance and scaling of font size in all browsers.
 2. Correct the odd 'em' font sizing in all browsers.
 */


### PR DESCRIPTION
The Web Specification recommends rendering 'b' and 'strong' elements with 'font-weight: bolder': https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3

Initially, Gecko/Firefox was the only major browsers engine using 'bolder'. Blink/Chromium and WebKit/Safari were using 'bold'.

As of 2025-02-20, Blink/Chromium uses 'bolder':
https://github.com/chromium/chromium/commit/0f34660cbc02352d5deabbf135c4b07303979df5

As of 2025-03-09, WebKit uses 'bolder' as well,
to align with the rest of the browser engines:
https://github.com/WebKit/WebKit/commit/2f7d04cbae67d35d6c3f2830cb134313c9b0dde1

Therefore, this normalization is no longer needed.