### PR TITLE
Improve cursor styling and comment for 'summary'

### DIFF
--- a/base.css
+++ b/base.css
@@ -384,9 +384,9 @@ Ref. https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
 ================================================== */
 
 /*
-Set the cursor on 'summary' elements to the same as buttons (default is 'text').
+Use the same cursor as buttons (default is 'text'), which feels more interactive, and aligns with its common implicit ARIA role of 'button'.
 */
 
-summary {
+:where(details > summary:first-of-type) {
 	cursor: default;
 }


### PR DESCRIPTION
- Aligns with the latest changes to the specification. [Link: https://github.com/whatwg/html/commit/0f1d234]
- Uses `:where()` to zero-out the specificity, allowing easier override of this style.
- The new comment clarifies the change from default 'text' to button's default 'default' and the rationale (interactive feel, ARIA role alignment).