### PR TITLE
ci(deps): Add retry-on-snapshot-warnings to dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           comment-summary-in-pr: always
           show-patched-versions: true
+          retry-on-snapshot-warnings: true


### PR DESCRIPTION
The dependency graph often hasn't indexed the PR head commit by the time the action runs, resulting in "No snapshots found" warnings and no files scanned. Retrying (default: every 10s, up to 120s) allows the snapshot to become available.